### PR TITLE
Fix aws cli missing python issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-browser:
     docker:
-      - image: cimg/node:14.17-browsers
+      - image: circleci/node:14.17-buster-browsers
     working_directory: /tmp/workspace
 
 jobs:


### PR DESCRIPTION
### Description:
We are building the react app in the CI pipeline and upload the artifacts to AWS S3 using aws cli, and it requires python.
Current CircleCI mainstream node docker images doesn't have python while the legacy images have, see the issue on the official repo:
https://github.com/CircleCI-Public/cimg-node/issues/108
https://github.com/CircleCI-Public/cimg-node/issues/65

And it seems like they are still maintaining the legacy images, so let's stick to legacy stream images instead of building our own image or using python variant image.