### PR TITLE
Chore/update circle orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/3.9.6-node
+      - image: cimg/python:3.9.6-node
     working_directory: /tmp/workspace
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
           arguments: |
             --acl public-read \
             --cache-control "max-age=86400"
-          overwrite: true
       - run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths /\*
 
   deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ workflows:
               only:
                 - master
                 - production
+                - chore/update-circle-orb
       - deploy:
           name: deploy-production
           requires:
@@ -97,6 +98,7 @@ workflows:
               only:
                 - master
                 - production
+                - chore/update-circle-orb
       - deploy-staging:
           name: deploy-staging
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,18 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.20
-  aws-s3: circleci/aws-s3@1.0.11
+  aws-cli: circleci/aws-cli@2.0.3
+  aws-s3: circleci/aws-s3@3.0.0
 
 executors:
-  node-browser:
+  node:
     docker:
-      - image: circleci/node:14.17-buster-browsers
+      - image: cimg/3.9.6-node
     working_directory: /tmp/workspace
 
 jobs:
   build:
-    executor: node-browser
+    executor: node
     working_directory: /tmp/workspace
     steps:
       - checkout
@@ -39,7 +39,7 @@ jobs:
             - build
 
   deploy:
-    executor: node-browser
+    executor: node
     working_directory: /tmp
     steps:
       - attach_workspace:
@@ -59,7 +59,7 @@ jobs:
       - run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths /\*
 
   deploy-staging:
-    executor: node-browser
+    executor: node
     working_directory: /tmp/workspace
     steps:
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ workflows:
               only:
                 - master
                 - production
-                - chore/update-circle-orb
       - deploy:
           name: deploy-production
           requires:
@@ -98,7 +97,6 @@ workflows:
               only:
                 - master
                 - production
-                - chore/update-circle-orb
       - deploy-staging:
           name: deploy-staging
           requires:


### PR DESCRIPTION
AWS recently updated cli so it no longer supports python 2(#104).
This PR updates aws orbs to the latest versions and docker image to python:3.9-node, which ships node v14.17.
Ref:  
https://github.com/CircleCI-Public/aws-s3-orb/pull/11  
`overwrite` has been removed, the param no longer exists and it overwrites by default.