### PR TITLE
remove staging and use master for staging cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
                 - production
       - build:
           name: build-production
@@ -80,17 +79,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
-                - production
-      - deploy-production:
-          name: deploy-production
-          requires:
-            - build-production
-          context: pastel-frontend-stage
-          filters:
-            branches:
-              only:
-                - master
                 - production
       - deploy-staging:
           name: deploy-staging
@@ -100,4 +88,13 @@ workflows:
           filters:
             branches:
               only:
-                - staging
+                - master
+      - deploy-production:
+          name: deploy-production
+          requires:
+            - build-production
+          context: pastel-frontend-stage
+          filters:
+            branches:
+              only:
+                - production


### PR DESCRIPTION
We will use `master` for staging deployment, and `production` for prod deployment.
No more automatic deployment for production environment. Only staging environment will get deployed automatically as soon as PRs are merged.