### PR TITLE
fix(view): transaction - fix message when the psl amount is unknown

### DIFF
--- a/src/pages/Details/TransactionDetails/TransactionDetails.helpers.tsx
+++ b/src/pages/Details/TransactionDetails/TransactionDetails.helpers.tsx
@@ -31,10 +31,14 @@ export const generateTableTitle = (transactionData: ITransactionDetails) => (
       The transaction is currently 
       ${
         transactionData.block.confirmations > BLOCK_CONFIRMED_NUMBER ? 'confirmed' : 'unconfirmed'
-      } by the network.
+      } by the network. 
       At the time of this transaction 
-      ${formatNumber(transactionData.totalAmount, { decimalsLength: 2 })} 
-      PSL was sent.`}
+      ${
+        transactionData.totalAmount
+          ? `${formatNumber(transactionData.totalAmount, { decimalsLength: 2 })} PSL was sent.`
+          : 'an unknown amount of PSL was sent (since it’s a shielded transaction).'
+      } 
+     `}
   </Alert>
 );
 


### PR DESCRIPTION
it shouldn’t say “0.0 PSL” was sent
it should say “an unknown amount of PSL was sent (since it’s a shielded transaction).”