### PR TITLE
Update the statistics and charts

### DIFF
--- a/src/pages/Statistics/BlockStatistics/BlockStatistics.tsx
+++ b/src/pages/Statistics/BlockStatistics/BlockStatistics.tsx
@@ -98,17 +98,44 @@ const StatisticsBlocks: React.FC = () => {
       setBlocksUnconfirmed(txs?.data || null);
     });
   };
+
   React.useEffect(() => {
+    handleBlocksData();
+
     socket.on('getUpdateBlock', () => {
       handleBlocksData();
     });
+
     return () => {
       socket.off('getUpdateBlock');
     };
   }, []);
-  React.useEffect(() => {
-    handleBlocksData();
-  }, []);
+
+  const renderMempoolBlock = () => {
+    if (blocksUnconfirmed?.length) {
+      const size = blocksUnconfirmed.reduce((a, b) => {
+        return a + b.size;
+      }, 0);
+      const txsCount = blocksUnconfirmed.reduce((a, b) => {
+        return a + b.txsCount;
+      }, 0);
+
+      return (
+        <Grid item>
+          <BlockVisualization
+            title="Mempool:"
+            height={<span style={{ fontSize: 14 }}>Pending Block</span>}
+            className="block-unconfirmed"
+            size={`${(size / 1024).toFixed(2)} kB`}
+            transactionCount={`${txsCount} ${txsCount > 1 ? 'transactions' : 'transaction'}`}
+            minutesAgo={`In ~${blocksUnconfirmed.length * 10} minutes`}
+          />
+        </Grid>
+      );
+    }
+
+    return null;
+  };
 
   return (
     <>
@@ -125,22 +152,7 @@ const StatisticsBlocks: React.FC = () => {
             alignItems="center"
             spacing={8}
           >
-            {blocksUnconfirmed && blocksUnconfirmed.length
-              ? blocksUnconfirmed.map(({ height, size, txsCount }, idx) => (
-                  <Grid item key={height}>
-                    <BlockVisualization
-                      title="Mempool:"
-                      height={<span style={{ fontSize: 14 }}>Pending Block</span>}
-                      className="block-unconfirmed"
-                      size={`${(size / 1024).toFixed(2)} kB`}
-                      transactionCount={`${txsCount} ${
-                        txsCount > 1 ? 'transactions' : 'transaction'
-                      }`}
-                      minutesAgo={`In ~${(blocksUnconfirmed.length - idx) * 10} minutes`}
-                    />
-                  </Grid>
-                ))
-              : null}
+            {renderMempoolBlock()}
             <Grid item>
               <div
                 style={{

--- a/src/pages/Statistics/BlockStatistics/BlockStatistics.tsx
+++ b/src/pages/Statistics/BlockStatistics/BlockStatistics.tsx
@@ -14,11 +14,12 @@ import { BlockUnconfirmed } from '@utils/types/ITransactions';
 
 import * as ROUTES from '@utils/constants/routes';
 import * as URLS from '@utils/constants/urls';
-import { useFetch } from '@utils/helpers/useFetch/useFetch';
+import { useFetch, useDeferredData } from '@utils/helpers/useFetch/useFetch';
 import { IBlock } from '@utils/types/IBlocks';
 import { useBackgroundChart } from '@utils/hooks';
+import { PeriodTypes } from '@utils/helpers/statisticsLib';
 
-import { info } from '@utils/constants/statistics';
+import { periods, info } from '@utils/constants/statistics';
 import { SocketContext } from '@context/socket';
 
 import BlockVisualization from './BlockVisualization/BlockVisualization';
@@ -57,9 +58,9 @@ const StatisticsBlocks: React.FC = () => {
   const history = useHistory();
   const classes = useStyles();
   const [blockElements, setBlockElements] = React.useState<Array<ITransformBlocksData>>([]);
-  const [chartData, setChartData] = React.useState<ChartProps | null>(null);
   const [currentBgColor, handleBgColorChange] = useBackgroundChart();
   const [blocksUnconfirmed, setBlocksUnconfirmed] = React.useState<BlockUnconfirmed[] | null>(null);
+  const [period, setPeriod] = React.useState(periods[5][0]);
   const fetchUnconfirmedTxs = useFetch<{ data: BlockUnconfirmed[] }>({
     method: 'get',
     url: URLS.GET_UNCONFIRMED_TRANSACTIONS,
@@ -86,13 +87,21 @@ const StatisticsBlocks: React.FC = () => {
 
     return groupedBlocks;
   };
+
+  const { isLoading, data: chartData } = useDeferredData<{ data: Array<IBlock> }, ChartProps>(
+    { method: 'get', url: `${URLS.BLOCK_URL}?period=${period}` },
+    ({ data }) => generateChartData(data),
+    undefined,
+    undefined,
+    [period, blockElements],
+  );
+
   const handleBlocksData = () => {
     Promise.all([
       fetchBlocksData.fetchData({ params: { limit: BLOCK_ELEMENTS_COUNT } }),
       fetchUnconfirmedTxs.fetchData(),
     ]).then(([blocksData, txs]) => {
       if (blocksData) {
-        setChartData(generateChartData(blocksData.data));
         setBlockElements(transformBlocksData(blocksData.data, blocksData.timestamp));
       }
       setBlocksUnconfirmed(txs?.data || null);
@@ -135,6 +144,10 @@ const StatisticsBlocks: React.FC = () => {
     }
 
     return null;
+  };
+
+  const handlePeriodFilterChange = (value: PeriodTypes) => {
+    setPeriod(value);
   };
 
   return (
@@ -180,7 +193,7 @@ const StatisticsBlocks: React.FC = () => {
           <Skeleton animation="wave" variant="rect" height={300} />
         )}
         <Grid item xs={12} lg={12}>
-          {chartData && (
+          {chartData || !isLoading ? (
             <div style={{ flex: 1, backgroundColor: currentBgColor }}>
               <EChartsLineChart
                 chartName="hashrate"
@@ -190,8 +203,13 @@ const StatisticsBlocks: React.FC = () => {
                 info={info}
                 offset={1}
                 handleBgColorChange={handleBgColorChange}
+                period={period}
+                periods={periods[5]}
+                handlePeriodFilterChange={handlePeriodFilterChange}
               />
             </div>
+          ) : (
+            <Skeleton animation="wave" variant="rect" height={300} />
           )}
         </Grid>
       </Grid>

--- a/src/pages/Statistics/TransactionStatistics/VolumeTransactions.tsx
+++ b/src/pages/Statistics/TransactionStatistics/VolumeTransactions.tsx
@@ -14,7 +14,7 @@ import { getCurrencyName } from '@utils/appInfo';
 const CHART_HEIGHT = 386;
 
 const NetworkStatistics: React.FC = () => {
-  const [period, setPeriod] = useState(periods[1][0]);
+  const [period, setPeriod] = useState(periods[4][0]);
   const [currentBgColor, handleBgColorChange] = useBackgroundChart();
 
   const { isLoading, data: chartData } = useDeferredData<IHashRateResponse, TLineChartData>(
@@ -41,7 +41,7 @@ const NetworkStatistics: React.FC = () => {
         info={info}
         offset={1000}
         period={period}
-        periods={periods[1]}
+        periods={periods[4]}
         handleBgColorChange={handleBgColorChange}
         handlePeriodFilterChange={handlePeriodFilterChange}
       />

--- a/src/utils/constants/statistics.ts
+++ b/src/utils/constants/statistics.ts
@@ -179,6 +179,8 @@ export const periods: PeriodTypes[][] = [
   ['30d', '60d', '180d', '1y', 'all'],
   ['1h', '3h', '6h', '12h'],
   ['24h', '7d', '14d', '30d', '60d', '180d', '1y', 'all'],
+  ['30d', '60d', '180d'],
+  ['1h', '1d', '7d', '30d'],
 ];
 
 export const CHART_THEME_BACKGROUND_DEFAULT_COLOR = '#0d0d0d';

--- a/src/utils/helpers/statisticsLib.ts
+++ b/src/utils/helpers/statisticsLib.ts
@@ -27,6 +27,7 @@ export type PeriodTypes =
   | '3h'
   | '6h'
   | '12h'
+  | '1d'
   | '2d'
   | '4d'
   | '7d'


### PR DESCRIPTION
- there should only be a single block on the left side representing the mempool
- and that should contain all the transactions that have not yet been included in a valid block
- and the size should be the total size of all of those unconfirmed transactions
- Added period to Block sizes (kB)
- Updated Volume of transactions (PSL) chart