### PR TITLE
fixed the last transactions are not updated

### DIFF
--- a/src/utils/hooks.tsx
+++ b/src/utils/hooks.tsx
@@ -39,6 +39,8 @@ export function useSortData<T>({
       if (inititalData && inititalData.length) {
         setList(inititalData);
       }
+    } else if (inititalData && inititalData.length && inititalData !== list) {
+      setList(inititalData);
     }
   }, [fetchData, inititalData]);
 


### PR DESCRIPTION
Fixed the last transactions are not updated when the user changed to the next/previous block by clicking on the arrow button.